### PR TITLE
Move IMAGE_DIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV SERVER_DIR="${HOMEDIR}/server"
 # IMAGE_DIR are files that are moved into SERVER_DIR at runtime
 # The purpose of it is for baking custom start/update scripts into your 
 # images and having them still appear in the server/ volume.
-ENV IMAGE_DIR="${HOMEDIR}/image"
+ENV IMAGE_DIR="/image"
 # For referencing inside server scripts in conjunction with IMAGE_DIR / SERVER_DIR. 
 # This just allows us to give them different names in the future.
 ENV STEAMCMD_UPDATE_SCRIPT="steam_update.txt"
@@ -25,7 +25,9 @@ RUN usermod -u ${PUID} ${USER} &&\
     groupmod -g ${PGID} ${USER} &&\
     chown ${USER}:${USER} /start.sh &&\
     chmod +x /start.sh &&\
+    mkdir "${IMAGE_DIR}" &&\
     mkdir "${SERVER_DIR}" &&\
+    chown ${USER}:${USER} "${IMAGE_DIR}" &&\
     chown ${USER}:${USER} "${SERVER_DIR}"
 WORKDIR "${SERVER_DIR}"
 USER ${USER}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	docker build -t steamcmd-server ./
 	find $(files) -maxdepth 1 -type d -exec \
 		/bin/sh -c 'dirname=$$(basename {}) &&\
-		docker build -t $(docker_user)/$$dirname:latest -t $(docker_user)/$$dirname:$(git_hash) {} &&\
+		docker build -t $$dirname -t $(docker_user)/$$dirname:latest -t $(docker_user)/$$dirname:$(git_hash) {} &&\
 		docker volume rm -f $$dirname' \;
 
 test:


### PR DESCRIPTION
- Scrap srcds-server for steamcmd-server
- Get everything working again
- Add README, update image FROM
- Update README
- Update README
- Update README
- Update README
- Update README
- Remove clean target
- Update README
- Update README
- Update README
- Update README
- Update README
- Update README
- Update README
- Update README
- Update README
- Update README
- Update README
- Move lines
- Fix Sven Co-op
- Add port to example
- Add port to make test
- Improve makefile
- Add STARTARGS
- Fix missing packages
- Change env var names
- Add table
- Update README
- Update README
- Update README
- Update README
- Update README
- Add options var to extend make test
- Update URLs
- Improve examples
- Improve examples
- Update README
- Fix image files not going to the server volume
- Fix make push
- Move image directory to root
- Fix make build
